### PR TITLE
move custom network type into the 'dataChanged / networkSettingsChang…

### DIFF
--- a/src/components/NetworkFrame.js
+++ b/src/components/NetworkFrame.js
@@ -870,17 +870,16 @@ class networkFrame extends React.Component {
           });
         });
       }
-      this.graphSettings = networkSettings;
-      this.graphSettings.numberOfNodes = nodes.length;
-      this.graphSettings.numberOfEdges = edges.length;
-    } else if (typeof networkSettings.type === "function") {
-      const customProjectedGraph = networkSettings.type({
-        nodes: projectedNodes,
-        edges: projectedEdges
-      });
 
-      projectedEdges = customProjectedGraph.edges || [];
-      projectedNodes = customProjectedGraph.nodes || [];
+      else if (typeof networkSettings.type === "function") {
+        // console.log("networkSettings is a function")
+        // console.log(networkSettings)
+        const customProjectedGraph = networkSettings.type({
+          nodes: projectedNodes,
+          edges: projectedEdges
+        });
+
+      } 
 
       this.graphSettings = networkSettings;
       this.graphSettings.numberOfNodes = nodes.length;


### PR DESCRIPTION
…ed' if clause.

Before the change, it seems that if we supply a custom networkType function, this function won't be used as it is evaluated outside the 'dataChanged / networkSettingsChanged' if clause. If I understood the intention correctly, this should be part of that clause for users who want full control of nodes & links generations. 